### PR TITLE
fix: perform cleanup on exit

### DIFF
--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -3,3 +3,6 @@ package event
 
 // SwitchToMainModel instructs Bubble Tea to display the main model
 type SwitchToMainModel struct{}
+
+// ShutdownMsg instructs a model to shutdown prior to shutdown
+type ShutdownMsg struct{}

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -65,6 +65,7 @@ func (m Model) View() string {
 	case Draw:
 		s += "Game over! It's a draw!\n\n"
 	case Forfeit:
+		fallthrough
 	case Win:
 		s += fmt.Sprintf("Game over! %s won!\n\n", string(m.game.Winner.Name))
 	}
@@ -165,7 +166,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tickCmd()
 		}
 		return m, nil
+	case event.ShutdownMsg:
+		e := StreamEvent{
+			Type: PlayerQuit,
+			Data: map[string]any{"player": m.player},
+		}
+		go func() {
+			m.game.Stream <- e
+		}()
+		return m, nil
 	}
+
 	return &m, cmd
 }
 

--- a/internal/queue/matchmaker.go
+++ b/internal/queue/matchmaker.go
@@ -2,6 +2,7 @@
 package queue
 
 import (
+	"slices"
 	"sync"
 	"time"
 
@@ -58,6 +59,20 @@ func (mm *Matchmaker) AddPlayer(p *player.Player) {
 			ok:      ok,
 		}
 	}()
+}
+
+// DelPlayer removes a player from the Matchmaker queue
+func (mm *Matchmaker) DelPlayer(p *player.Player) {
+	mm.mu.Lock()
+	defer mm.mu.Unlock()
+
+	mm.players = func(p *player.Player) []*player.Player {
+		index := slices.Index(mm.players, p)
+		if index == -1 {
+			return mm.players
+		}
+		return append(mm.players[:index], mm.players[index+1:]...)
+	}(p)
 }
 
 // WatchResults continuously watches a Matchmaker's Results channel

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/bubbles/timer"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/yamlinson/t3/internal/event"
 	"github.com/yamlinson/t3/internal/game"
 	"github.com/yamlinson/t3/internal/player"
 )
@@ -52,6 +53,7 @@ func (m Model) View() string {
 		s = fmt.Sprintf("Please enter your name...\n\n%s\n\n%s", m.textInput.View(), m.errMsg)
 	case queued:
 		s = fmt.Sprintf("Hello, %s!\n\nFinding an opponent...\n", m.player.Name)
+		s += "Press 'q' to leave queue\n\n"
 	case matched:
 		seconds := int(m.timer.Timeout.Seconds())
 		s = "Match found! Would you like to accept? (Y/n)\n\n"
@@ -90,6 +92,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						return playerAdded{}
 					},
 				)
+			}
+		case queued:
+			switch msg.String() {
+			case "q":
+				m.matchmaker.DelPlayer(m.player)
+				m.state = nameInput
+				return &m, nil
 			}
 		case matched:
 			switch msg.String() {
@@ -132,6 +141,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmd = func() tea.Msg { return game.SwitchToGameModel{Game: m.game} }
 			m.timer.Stop()
 		}
+	case event.ShutdownMsg:
+		m.matchmaker.DelPlayer(m.player)
+		return &m, nil
 	}
 
 	if m.state == nameInput {

--- a/main.go
+++ b/main.go
@@ -124,6 +124,7 @@ func (m mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 	case tea.KeyMsg:
 		if msg.String() == "ctrl+c" {
+			m.activeModel, _ = m.activeModel.Update(event.ShutdownMsg{})
 			return &m, tea.Quit
 		}
 	case game.SwitchToGameModel:


### PR DESCRIPTION
When a player presses 'ctrl+c', the queue and game models are notified before quit so they can clean up.

Queue now removes the player from the matchmaking queue

Game sends a forfeit message

Resolves #4 