### PR TITLE
fix: container issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,27 @@
-FROM golang:1.26.1-alpine AS builder
+FROM golang:1.26.1-bookworm AS builder
 
-RUN apk --no-cache add ca-certificates git
 
 WORKDIR /app
-
 COPY go.mod go.sum ./
-
 RUN go mod download
 
 COPY . .
 
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o t3 .
+RUN CGO_ENABLED=1 GOOS=linux go build -o t3 .
 
-FROM gcr.io/distroless/static:nonroot
+FROM debian:bookworm-slim
 
-COPY --from=builder --chown=nonroot:nonroot /app/t3 /
+COPY --from=builder /app/t3 /
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 
-USER nonroot:nonroot
+RUN adduser --disabled-password --gecos '' --shell /bin/false appuser
+RUN mkdir -p /data && \
+    chown appuser:appuser /data && \
+    chmod 0755 /data
+RUN mkdir -p /.ssh && \
+    chown appuser:appuser /.ssh && \
+    chmod 0755 /.ssh
+USER appuser:appuser
 
 EXPOSE 2222
-
 CMD ["/t3"]

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	host = "localhost"
+	host = "0.0.0.0"
 	port = "2222"
 )
 
@@ -56,7 +56,9 @@ func main() {
 
 		initialModel := initMainModel(p, mm, database)
 
-		return initialModel, []tea.ProgramOption{tea.WithAltScreen()}
+		return initialModel, []tea.ProgramOption{
+			tea.WithAltScreen(),
+		}
 	}
 
 	s, err := wish.NewServer(


### PR DESCRIPTION
sqlite driver needs cgo enabled, which means distroless won't work as a base image

also, the server was only binding on localhost and needed to be set to any